### PR TITLE
Add SyntaxError handling for countdown evaluator

### DIFF
--- a/longproc/countdown_evaluator.py
+++ b/longproc/countdown_evaluator.py
@@ -209,7 +209,10 @@ def evaluate_countdown_final_solution(nums: list, target: int, solution: str) ->
     for line in lines:
         try:
             correct, a, b, c, op = _parse_line(line)
+        # Catch malformed equation lines: ValueError (bad format) and SyntaxError (invalid expression)
         except ValueError:
+            return False
+        except SyntaxError:
             return False
         if not correct:
             return False


### PR DESCRIPTION
Capture SyntaxError in addition to ValueError when parsing equation lines in the countdown evaluator. Handles malformed equation lines that fail to parse.

## Motivation

Without this fix, the evaluator crashes when the model produces non-equation text that gets passed to `eval()` in `_parse_line`. Here's what I hit

```
  File "/app/longproc_repo/longproc/longproc_data.py", line 260, in eval_countdown
    if pred_solution is not None and evaluate_countdown_final_solution(nums, target, pred_solution):
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/longproc_repo/longproc/countdown_evaluator.py", line 211, in evaluate_countdown_final_solution
    correct, a, b, c, op = _parse_line(line)
                            ^^^^^^^^^^^^^^^^^
  File "/app/longproc_repo/longproc/countdown_evaluator.py", line 190, in _parse_line
    lhs_result = eval(lhs)
                 ^^^^^^^^^
  File "<string>", line 1
    8 + 3 is not in the search procedure, we need to go back to the first step of the search procedure. The first step is: 45 - 37
                ^^
SyntaxError: invalid syntax
```

In this case the model output free-form text instead of a valid equation, causing `eval(lhs)` to raise `SyntaxError`. We now catch both `ValueError` and `SyntaxError` and treat them as invalid solutions (return `False`) instead of crashing.

Made with [Cursor](https://cursor.com)